### PR TITLE
<fix> 필터옵션 변경시 게시판 목록이 갱신되지 않던 문제 해결

### DIFF
--- a/src/components/Party/PartyList.tsx
+++ b/src/components/Party/PartyList.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useState } from 'react';
-import { Box, CircularProgress, Stack, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import PartyListItem from './PartyListItem';
 import { IPartyListItem } from '../../types/party';
 import { PartyListContainer } from '../../styles/pages/party/PartyList.styles';
@@ -39,24 +39,24 @@ const PartyList = forwardRef<HTMLDivElement, TPartyListProps>(
 			<PartyListContainer>
 				{/* <Stack> */}
 				{data?.pages
-						.flatMap((page) => page)
-						.map((party: IPartyListItem) =>
-							party ? (
-								<PartyListItem
-									key={party.id}
-									party={party}
-									expandedPartyId={expandedPartyId}
-									setExpandedPartyId={setExpandedPartyId}
-								/>
-							) : null
-						)}
-					<Box ref={ref} display='flex' justifyContent='center' py={4}>
-						{isFetching ? (
-							<CircularProgress />
-						) : hasNextPage ? null : (
-							<Typography variant='body1'>더이상 파티가 없습니다.</Typography>
-						)}
-					</Box>
+					.flatMap((page) => page)
+					.map((party: IPartyListItem) =>
+						party ? (
+							<PartyListItem
+								key={party.id}
+								party={party}
+								expandedPartyId={expandedPartyId}
+								setExpandedPartyId={setExpandedPartyId}
+							/>
+						) : null
+					)}
+				<Box ref={ref} display='flex' justifyContent='center' py={4}>
+					{isFetching ? (
+						<CircularProgress />
+					) : hasNextPage ? null : (
+						<Typography variant='body1'>더이상 파티가 없습니다.</Typography>
+					)}
+				</Box>
 				{/* </Stack> */}
 			</PartyListContainer>
 		);

--- a/src/hooks/useParties.ts
+++ b/src/hooks/useParties.ts
@@ -53,10 +53,10 @@ export const useInfiniteParties = (getPartiesData: IGetPartiesData) => {
 		IPartiesResponse,
 		Error,
 		InfiniteData<IPartiesResponse>,
-		['parties', 'all'],
+		['parties', 'all', TFilterOption[]],
 		number
 	>({
-		queryKey: ['parties', 'all'],
+		queryKey: ['parties', 'all', getPartiesData.filterOptions],
 		queryFn: ({ pageParam = 1 }) => {
 			// 쿼리 파라미터터 생성
 			const { filterOptions, pagination } = getPartiesData;


### PR DESCRIPTION
## 변경사항
useParties 훅에서 쿼리키 추가를 통해 필터 옵션에따라 parties가 갱신됩니다.
추가적으로 같은 옵션에 대한 쿼리 기능 향상도 기대할 수 있을 것 같습니다.